### PR TITLE
lxqt_translate_desktop: pass -h instead of --no-filename to grep which is compatible with Busybox

### DIFF
--- a/cmake/modules/LXQtTranslateDesktop.cmake
+++ b/cmake/modules/LXQtTranslateDesktop.cmake
@@ -63,7 +63,7 @@ function(lxqt_translate_desktop _RESULT)
         if (_translations)
             add_custom_command(OUTPUT ${_outFile}
                 COMMAND grep -v "'#TRANSLATIONS_DIR='" ${_inFile} > ${_outFile}
-                COMMAND grep --no-filename ${_pattern} ${_translations} >> ${_outFile}
+                COMMAND grep -h ${_pattern} ${_translations} >> ${_outFile}
                 COMMENT "Generating ${_fileName}${_fileExt}"
             )
         else()


### PR DESCRIPTION
https://www.gnu.org/software/grep/manual/grep.html#Output-Line-Prefix-Control