### PR TITLE
Workaround Qt 5.4 issue: Re-add a config file to the file watcher if it's already deleted to get proper change notifications.

### DIFF
--- a/lxqtsettings.h
+++ b/lxqtsettings.h
@@ -86,7 +86,11 @@ protected:
     bool event(QEvent *event);
 
 protected slots:
+    /*! Called when the config file is changed */
     virtual void fileChanged();
+
+private slots:
+    void _fileChanged(QString path);
 
 private:
     Q_DISABLE_COPY(Settings)


### PR DESCRIPTION
This is to fix lxde/lxqt#441 - [Regression] All LXQt::Settings and QSettings file change monitoring stop working.
https://github.com/lxde/lxqt/issues/441