### PR TITLE
- Remove KF5 from prefix. This will fix compilation when KDE framework h...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ find_package(Qt5Widgets REQUIRED QUIET)
 find_package(Qt5DBus REQUIRED QUIET)
 find_package(Qt5X11Extras REQUIRED QUIET)
 find_package(Qt5LinguistTools REQUIRED QUIET)
-find_package(Qt5Xdg REQUIRED)
+find_package(Qt5Xdg REQUIRED QUIET)
 find_package(KF5WindowSystem REQUIRED QUIET)
 message(STATUS "Building with Qt ${Qt5Core_VERSION_STRING}")
 

--- a/lxqtsingleapplication.cpp
+++ b/lxqtsingleapplication.cpp
@@ -27,8 +27,8 @@
 
 #include "lxqtsingleapplication.h"
 #include "singleapplicationadaptor.h"
-#include <KF5/KWindowSystem/KWindowSystem>
-#include <KF5/KWindowSystem/NETWM>
+#include <KWindowSystem/KWindowSystem>
+#include <KWindowSystem/NETWM>
 #include <QDBusMessage>
 #include <QWidget>
 #include <QDebug>


### PR DESCRIPTION
...eaders are not in standard paths.