### PR TITLE
addplugindialog: support for managing plugins

### DIFF
--- a/addplugindialog/lxqtaddplugindialog.h
+++ b/addplugindialog/lxqtaddplugindialog.h
@@ -39,9 +39,23 @@ namespace Ui {
     class AddPluginDialog;
 }
 
+class QMenu;
+
 
 namespace LxQt
 {
+
+/*! Information about existing/running plugin
+ */
+struct PluginData
+{
+    PluginData(QString const & _typeId, QObject * const _plugin, QMenu * const _pluginMenu)
+        : typeId(_typeId), plugin(_plugin), pluginMenu(_pluginMenu) {}
+
+    QString typeId; //!< plugin Id - name of desktop file (w/o .desktop)
+    QObject* plugin; //!< plugin instance (used just for instance identification)
+    QSharedPointer<QMenu> pluginMenu; //!< menu(actions) to show for this instance of plugin
+};
 
 /*! The AddPluginDialog class provides a dialog that allow users to add plugins.
  */
@@ -62,6 +76,11 @@ public:
 
     ~AddPluginDialog();
 
+    /*! Set information of existing/running plugin instances
+     */
+    void setPluginsInUse(QList<PluginData> const & pluginsInUse);
+    /*! Obsolete, use setPluginsInUse(QList<PluginData> const & pluginsInUse) instead
+     */
     void setPluginsInUse(const QStringList pluginsInUseIDs);
 
 signals:
@@ -78,15 +97,23 @@ private:
 
     // store the amount of instances of the plugins using their ids
     QHash<QString, int> mPluginsInUseAmount;
+    QList<PluginData> mPluginsInfo;
 
 public slots:
+    void pluginAdded(PluginData const & plugin);
+    void pluginRemoved(PluginData const & plugin);
+    /*! Obsolete, use pluginAdded(PluginData const & plugin) instead
+     */
     void pluginAdded(const QString &id);
+    /*! Obsolete, use pluginRemoved(PluginData const & plugin) instead
+     */
     void pluginRemoved(const QString &id);
 
 private slots:
     void emitPluginSelected();
     void searchEditTexChanged(const QString& text);
     void toggleAddButtonState();
+    void showContextMenu(const QPoint& pos);
 };
 
 } // namecpase LxQt


### PR DESCRIPTION
references lxde/lxqt#536, lxde/lxqt#552 (and maybe others)
coupled with (must be merged first) lxde/lxqt-panel#160

Added viewing of delegated context menu for each plugin type:
- in list user can invoke context menu (right-click, 'menu' key) to manage all plugins of current type

Issues/questions:
- the 'Add widget' button now may be obsolete
- the context menu may be a bit tricky for users -> should we add a note somewhere about it?
- i had just a quick search if the dialog is used elsewhere in lxqt and found nothing but `lxqt-panel`. Should we be backward compatible (=> leave old overloads for `pluginAdded`, `pluginRemoved` & `setPluginsInUse`)