### PR TITLE
fix build with qt 5.5

### DIFF
--- a/lxqtnotification.h
+++ b/lxqtnotification.h
@@ -25,6 +25,7 @@
 #ifndef LXQTNOTIFICATION_H
 #define LXQTNOTIFICATION_H
 
+#include <QObject>
 #include <QStringList>
 #include "lxqtglobals.h"
 


### PR DESCRIPTION
(lxqtnotification.h:43:5: error: 'Q_OBJECT' does not name a type)