### PR TITLE
Removes Cannot open qss file

### DIFF
--- a/lxqtsettings.cpp
+++ b/lxqtsettings.cpp
@@ -482,7 +482,6 @@ QString LxQtThemeData::loadQss(const QString& qssFile) const
     QFile f(qssFile);
     if (! f.open(QIODevice::ReadOnly | QIODevice::Text))
     {
-        qWarning() << "Theme: Cannot open file for reading:" << qssFile;
         return QString();
     }
 


### PR DESCRIPTION
There's lot's of components that don't have an theme file. There's no need
to issue a warning, not even an debug message.