### PR TITLE
Lock screen on suspend and hibernate

### DIFF
--- a/lxqtpower/lxqtpower.cpp
+++ b/lxqtpower/lxqtpower.cpp
@@ -34,8 +34,10 @@
 using namespace LxQt;
 
 Power::Power(QObject *parent) :
-    QObject(parent)
+    QObject(parent),
+    mScreenSaver(this)
 {
+    connect(&mScreenSaver, SIGNAL(done()), &mLoop, SLOT(quit()));
     mProviders.append(new CustomProvider(this));
     mProviders.append(new SystemdProvider(this));
     mProviders.append(new UPowerProvider(this));
@@ -66,11 +68,18 @@ bool Power::doAction(Power::Action action)
 {
     foreach(PowerProvider* provider, mProviders)
     {
-        if (provider->canAction(action) &&
-            provider->doAction(action)
-           )
+        if (provider->canAction(action))
         {
-            return true;
+            if (action == PowerSuspend || action == PowerHibernate)
+            {
+                mScreenSaver.lockScreen();
+                mLoop.exec();
+            }
+            if (provider->doAction(action))
+            {
+                return true;
+            }
+            return false;
         }
     }
     return false;

--- a/lxqtpower/lxqtpower.h
+++ b/lxqtpower/lxqtpower.h
@@ -31,6 +31,8 @@
 
 #include <QObject>
 #include <QList>
+#include <QEventLoop>
+#include "lxqtscreensaver.h"
 #include "lxqtglobals.h"
 
 namespace LxQt
@@ -101,6 +103,8 @@ public slots:
 
 private:
     QList<PowerProvider*> mProviders;
+    LxQt::ScreenSaver mScreenSaver;
+    QEventLoop mLoop;
 };
 
 } // namespace LxQt


### PR DESCRIPTION
Fixes lxde/lxqt#775.

The title pretty much says all.
This patch used to be a personal quick-fix, and as such, I don't know if this is the proper way to do it. Neither do I know for sure if this behaviour is acutally expected, or should be configureable or something.
Also, this patch has only been tested on liblxqt-0.9.0, and I haven't tested it on current master, yet I see no reason why it should work any different (secretly I'm too lazy to recompile libqtxdg to master).