### PR TITLE
Screensaver: rely on xdg-util's xscreensaver-command

### DIFF
--- a/lxqtscreensaver.h
+++ b/lxqtscreensaver.h
@@ -32,6 +32,7 @@
 #include <QObject>
 #include <QProcess>
 #include <QAction>
+#include <QMessageBox>
 
 namespace LXQt
 {
@@ -48,14 +49,17 @@ public:
 signals:
     void activated();
     void done();
+
 public slots:
     void lockScreen();
 
 private:
-    QProcess * m_xdgProcess;
+    QProcess mProcess;
+    QMessageBox messageBox;
 
 private slots:
-    void xdgProcess_finished(int err, QProcess::ExitStatus status);
+    void onError(QProcess::ProcessError error);
+    void onReadyRead();
 
 };
 


### PR DESCRIPTION
`xdg-screensaver` works but doesn't give valuable output. We can't know if the screen is already locked or the locking failed. With `xscreensaver-command`, we have refined output, although in string form.

This has a drawback: if the user is running an app that relies on liblxqt's Screensaver (e.g. lxqt-powermanagement, lxqt-panel, lxqt-runner) outside of LXQt, the specific DE's screensaver will be triggered, but X's default. It's probably not a current common use case. Anyway, in the near future we will provide our own implementation of `org.freedesktop.ScreenSaver` in DBus and that will be solved.

Related to lxde/lxqt#833.