### PR TITLE
license fix for AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,7 +4,9 @@ Upstream Authors:
 
 Copyright:
     Copyright (c) 2010-2012 Razor team
-    Copyright (c) 2012-2014 LXQt team
+    Copyright (c) 2012-2015 LXQt team
 
-License: GPL-2 and LGPL-2.1+
-The full text of the licenses can be found in the 'COPYING' file.
+License: LGPL-2.1+ and BSD-3-clause
+The full text of the LGPL-2.1+ licenses can be found in the 'COPYING' file.
+The full text of the BSD-3-clause license can be found in the headers of
+the files under this license.


### PR DESCRIPTION
some files in cmake/modules are under BSD-3-clause
GPL isn't used at all