### PR TITLE
gridlayout: Use linear animation

### DIFF
--- a/lxqtgridlayout.cpp
+++ b/lxqtgridlayout.cpp
@@ -50,8 +50,7 @@ namespace
         ItemMoveAnimation(QLayoutItem *item)
             : mItem(item)
         {
-            setEasingCurve(QEasingCurve::OutBack);
-            setDuration(250);
+            setDuration(150);
         }
 
         void updateCurrentValue(const QVariant &current)


### PR DESCRIPTION
We should be "light" & the QEasingCurve::Linear should be the less resources expensive one.