### PR TITLE
SingleApplication: Call also QWidget::show on activate

### DIFF
--- a/lxqtsingleapplication.cpp
+++ b/lxqtsingleapplication.cpp
@@ -95,6 +95,7 @@ QWidget *SingleApplication::activationWindow() const
 void SingleApplication::activateWindow()
 {
     if (mActivationWindow) {
+        mActivationWindow->show();
         WId window = mActivationWindow->effectiveWinId();
 
         KWindowInfo info(window, NET::WMDesktop);


### PR DESCRIPTION
Needed if the application is hidden (not only minimized), e.g. for lxqt-runner

needed by lxde/lxqt-runner#38