### PR TITLE
settings: Upgrade emitting of "changed" signals

### DIFF
--- a/lxqtsettings.h
+++ b/lxqtsettings.h
@@ -80,7 +80,15 @@ public:
     void setLocalizedValue(const QString &key, const QVariant &value);
 
 signals:
+    /*! /brief signal for backward compatibility (emitted whenever settingsChangedFromExternal() or settingsChangedByApp() is emitted)
+     */
     void settingsChanged();
+    /*! /brief signal emitted when the settings file is changed by external application
+     */
+    void settingsChangedFromExternal();
+    /*! /brief signal emitted when any setting is changed by this object
+     */
+    void settingsChangedByApp();
 
 protected:
     bool event(QEvent *event);
@@ -91,6 +99,9 @@ protected slots:
 
 private slots:
     void _fileChanged(QString path);
+
+private:
+    void addWatchedFile(QString const & path);
 
 private:
     Q_DISABLE_COPY(Settings)


### PR DESCRIPTION
- Same signal settingsChanged() was emitted upon object based change (setValue(), erase()...) and
upon change made by external entity (watching the file changes) => we added other two signals
settingsChangedFromExternal() & settingsChangedByApp() to make these changes distinguishable. The signal settingsChanged() was left for backwards compatibility.

- Emitting of settingsChanged*() signals was delayed to be able to distinguish if change made on file was based upon our write/sync or by external application.

This is needed by lxde/lxqt-panel#294