### PR TITLE
[wip] translations: Add support for external translations

### DIFF
--- a/cmake/modules/LXQtTranslateTs.cmake
+++ b/cmake/modules/LXQtTranslateTs.cmake
@@ -168,14 +168,19 @@ function(lxqt_translate_ts qmFiles)
         endif ()
         if (NOT EXISTS "${TR_TRANSLATION_DIR}/${TR_REPO_SUBDIR}")
             message(STATUS "Setting git repository in the translations dir '${TR_TRANSLATION_DIR}' ...")
+            if (EXISTS "${TR_TRANSLATION_DIR}/.git")
+                execute_process(COMMAND rm -Rf .git
+                    WORKING_DIRECTORY  "${TR_TRANSLATION_DIR}"
+                    RESULT_VARIABLE ex_result
+                    )
 
-            execute_process(COMMAND rm -Rf .git
-                WORKING_DIRECTORY  "${TR_TRANSLATION_DIR}"
-                RESULT_VARIABLE ex_result
-                )
-            if (NOT "${ex_result}" EQUAL 0)
-                message(FATAL_ERROR "Initialization(cleanup) of translations dir failed!")
-            endif ()
+                if (NOT "${ex_result}" EQUAL 0)
+                    message(FATAL_ERROR "Initialization(cleanup) of translations dir failed!")
+                endif ()
+            endif()
+
+            # make sure the dir exist, otherwise git init will fail
+            file(MAKE_DIRECTORY "${TR_TRANSLATION_DIR}")
 
             execute_process(COMMAND "${GIT_EXECUTABLE}" init
                 WORKING_DIRECTORY  "${TR_TRANSLATION_DIR}"


### PR DESCRIPTION
Translations now can be pulled from external git repository, if enabled by LXQT_PULL_TRANSLATIONS.

Pulling of external translations files is performed in cmake phase (not in build time) into project source dir =>
- not (re)pulled in build time (after make invocation)
- translations dir is not "cleaned" in make clean
- translations dir will be "cleaned" in cmake phase if LXQT_CLEAN_TRANSLATIONS is set

TODO:
- [x] ~~unify for \*.ts \& \*.desktop translations~~ (not needed)
- [x] add support for defining the pulled directory (now it probably will not work for panel plugins etc.)
- [x] add support for selecting branch/tag/commit of translations repo to be pulled

@jleclanche @luis-pereira @paulolieuthier @PCMan Have a look on this proposal.
Is it worth continuing by this approach?