### PR TITLE
SingleApplication: Use QCoreApplication::exit() instead of ::exit()

### DIFF
--- a/lxqtsingleapplication.cpp
+++ b/lxqtsingleapplication.cpp
@@ -32,6 +32,7 @@
 #include <QDBusMessage>
 #include <QWidget>
 #include <QDebug>
+#include <QTimer>
 
 using namespace LXQt;
 
@@ -57,7 +58,7 @@ SingleApplication::SingleApplication(int &argc, char **argv, StartOptions option
             return;
         } else {
             qCritical() << Q_FUNC_INFO << errorMessage;
-            ::exit(1);
+            QTimer::singleShot(0, [this] { exit(1); });
         }
     }
 
@@ -74,7 +75,7 @@ SingleApplication::SingleApplication(int &argc, char **argv, StartOptions option
             QStringLiteral("activateWindow"));
         QDBusConnection::sessionBus().send(msg);
 
-        ::exit(0);
+        QTimer::singleShot(0, [this] { exit(0); });
     }
 }
 


### PR DESCRIPTION
fixes lxde/lxqt#951

But I'm not sure if this is the right way...the application's `exec()` will return "immediately", but all the initialization (outside of QApplication/.../SingleApplication) will be performed (creating widgets etc.).
