### PR TITLE
configdialog: Update icons in ThemeChanged event

### DIFF
--- a/configdialog/lxqtconfigdialog.cpp
+++ b/configdialog/lxqtconfigdialog.cpp
@@ -40,7 +40,6 @@ ConfigDialog::ConfigDialog(const QString& title, Settings* settings, QWidget* pa
     setWindowTitle(title);
     connect(ui->buttons, SIGNAL(clicked(QAbstractButton*)), SLOT(dialogButtonsAction(QAbstractButton*)));
     ui->moduleList->setVisible(false);
-    connect(Settings::globalSettings(), SIGNAL(settingsChanged()), this, SLOT(updateIcons()));
     foreach(QPushButton* button, ui->buttons->findChildren<QPushButton*>())
         button->setAutoDefault(false);
 }
@@ -102,6 +101,13 @@ void ConfigDialog::showPage(QWidget* page)
 
     ui->stackedWidget->setCurrentIndex(index);
     ui->moduleList->setCurrentRow(index);
+}
+
+bool ConfigDialog::event(QEvent * event)
+{
+    if (QEvent::ThemeChange == event->type())
+        updateIcons();
+    return QDialog::event(event);
 }
 
 void ConfigDialog::closeEvent(QCloseEvent* event)

--- a/configdialog/lxqtconfigdialog.h
+++ b/configdialog/lxqtconfigdialog.h
@@ -89,7 +89,8 @@ signals:
 
 protected:
     Settings* mSettings;
-    virtual void closeEvent(QCloseEvent* event);
+    virtual bool event(QEvent * event) override;
+    virtual void closeEvent(QCloseEvent* event) override;
 
 private:
     SettingsCache* mCache;


### PR DESCRIPTION
We don't need/want to handle global settings change. lxqt-qtplugin is handling that.
We just need to know that the theme was changed.