### PR TITLE
NotificationPrivate: Fixes programming typo

### DIFF
--- a/lxqtnotification.cpp
+++ b/lxqtnotification.cpp
@@ -189,7 +189,7 @@ void NotificationPrivate::handleAction(uint id, QString key)
     else
         keyId = key.toInt(&ok);
 
-    if (ok && key >= 0)
+    if (ok && keyId >= 0)
         emit q->actionActivated(keyId);
 }
 


### PR DESCRIPTION
Automatic casts tricked the compiler.