### PR TITLE
lxqtscreensaver: Makes it a opaque pointer class

### DIFF
--- a/lxqtscreensaver.h
+++ b/lxqtscreensaver.h
@@ -30,18 +30,22 @@
 
 #include "lxqtglobals.h"
 #include <QObject>
-#include <QProcess>
 #include <QAction>
 
 namespace LXQt
 {
 
+class ScreenSaverPrivate;
+
 class LXQT_API ScreenSaver : public QObject
 {
     Q_OBJECT
+    Q_DECLARE_PRIVATE(ScreenSaver)
+    Q_DISABLE_COPY(ScreenSaver)
 
 public:
     ScreenSaver(QObject * parent=0);
+    ~ScreenSaver();
 
     QList<QAction*> availableActions();
 
@@ -52,11 +56,9 @@ public slots:
     void lockScreen();
 
 private:
-    QProcess * m_xdgProcess;
+    ScreenSaverPrivate* const d_ptr;
 
-private slots:
-    void xdgProcess_finished(int err, QProcess::ExitStatus status);
-
+    Q_PRIVATE_SLOT(d_func(), void _l_xdgProcess_finished(int, QProcess::ExitStatus))
 };
 
 } // namespace LXQt


### PR DESCRIPTION
It helps with where the implementation details of a library may be hidden
from its users and changes to the implementation can be made to a library
without breaking binary compatibility.