### PR TITLE
Fix lupdate warning missing Q_OBJECT macro

### DIFF
--- a/lxqtpowermanager.cpp
+++ b/lxqtpowermanager.cpp
@@ -41,6 +41,8 @@ namespace LXQt {
 
 class LXQT_API MessageBox: public QMessageBox
 {
+    Q_DECLARE_TR_FUNCTIONS(LXQt::MessageBox);
+
 public:
     explicit MessageBox(QWidget *parent = 0): QMessageBox(parent) {}
 


### PR DESCRIPTION
We don't need to add the Q_OBJECT macro. Just use the
Q_DECLARE_TR_FUNCTIONS macro.