### PR TITLE
Bump needed build tools version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(liblxqt)
 
 set(QT_MINIMUM_VERSION "5.4.2")
 set(QTXDG_MINIMUM_VERSION "2.0.0")
-set(LXQTBT_MINIMUM_VERSION "0.3.0")
+set(LXQTBT_MINIMUM_VERSION "0.3.1")
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs) # Standard directories for installation


### PR DESCRIPTION
As liblxqt picks its version from build tools the minimum build tools version is the to be released version