### PR TITLE
Translator: Prefer XDG_DATA_DIRS over compiled in path

### DIFF
--- a/lxqttranslator.cpp
+++ b/lxqttranslator.cpp
@@ -51,8 +51,8 @@ QStringList *getSearchPaths()
     if (searchPath == 0)
     {
         searchPath = new QStringList();
-        *searchPath << QString(LXQT_SHARE_TRANSLATIONS_DIR);
         *searchPath << XdgDirs::dataDirs(QLatin1Char('/') % LXQT_RELATIVE_SHARE_TRANSLATIONS_DIR);
+        *searchPath << QString(LXQT_SHARE_TRANSLATIONS_DIR);
         searchPath->removeDuplicates();
     }
 


### PR DESCRIPTION
Use the compiled in LXQT_SHARE_TRANSLATIONS_DIR as the last fallback,
t. m. prefer the XDG_DATA_DIRS%LXQT_RELATIVE_SHARE_TRANSLATIONS_DIR in
run-time.