### PR TITLE
lxqtpowermanager: Do logout before reboot/shutdown

### DIFF
--- a/lxqtpowermanager.cpp
+++ b/lxqtpowermanager.cpp
@@ -177,6 +177,7 @@ void PowerManager::reboot()
         MessageBox::question(tr("LXQt Session Reboot"),
                              tr("Do you want to really restart your computer? All unsaved work will be lost...")))
     {
+        m_power->logout();
         m_power->reboot();
     }
 }
@@ -187,6 +188,7 @@ void PowerManager::shutdown()
         MessageBox::question(tr("LXQt Session Shutdown"),
                              tr("Do you want to really switch off your computer? All unsaved work will be lost...")))
     {
+        m_power->logout();
         m_power->shutdown();
     }
 }


### PR DESCRIPTION
Try to terminate the running processes/modules in prefered order (the
session's logout procedure should know how to do it). Aftert that invoke
the particular reboot/shutdown.

W/o the logout before reboot/shutdown the reboot/shutdown provider
(namely systemd) was terminating all proceses in undefined (random?)
order which could lead to insane shutdown and/or deadlocks with poorly
written applications/libraries.

closes lxde/lxqt#1311