### PR TITLE
lxqtpower: Allow disabling of lxqt-session provider

### DIFF
--- a/lxqtpower/lxqtpower.cpp
+++ b/lxqtpower/lxqtpower.cpp
@@ -33,15 +33,21 @@
 
 using namespace LXQt;
 
-Power::Power(QObject *parent) :
+Power::Power(bool useLxqtSessionProvider, QObject * parent /*= nullptr*/) :
     QObject(parent)
 {
     mProviders.append(new CustomProvider(this));
+    if (useLxqtSessionProvider)
+        mProviders.append(new LXQtProvider(this));
     mProviders.append(new SystemdProvider(this));
     mProviders.append(new UPowerProvider(this));
     mProviders.append(new ConsoleKitProvider(this));
     mProviders.append(new LxSessionProvider(this));
-    mProviders.append(new LXQtProvider(this));
+}
+
+Power::Power(QObject * parent /*= nullptr*/)
+    : Power(true, parent)
+{
 }
 
 

--- a/lxqtpower/lxqtpower.h
+++ b/lxqtpower/lxqtpower.h
@@ -56,8 +56,16 @@ public:
         PowerSuspend    /// Suspend the computer
     };
 
-    /// Constructs a Power with parent.
-    explicit Power(QObject *parent = 0);
+    /*!
+     * Constructs the Power object.
+     * \param useLxqtSessionProvider indicates if the DBus methods
+     * provided by lxqt-session should be considered. This is useful to
+     * avoid recursion if the lxqt-session wants to provide some of the
+     * methods by itself with internal use of this object.
+     */
+    explicit Power(bool useLxqtSessionProvider, QObject *parent = nullptr);
+    /// Constructs a Power with using the lxqt-session provider.
+    explicit Power(QObject *parent = nullptr);
 
     /// Destroys the object.
     virtual ~Power();

--- a/lxqtpower/lxqtpowerproviders.cpp
+++ b/lxqtpower/lxqtpowerproviders.cpp
@@ -500,31 +500,45 @@ LXQtProvider::~LXQtProvider()
 
 bool LXQtProvider::canAction(Power::Action action) const
 {
+    QString command;
     switch (action)
     {
         case Power::PowerLogout:
-            // there can be case when razo-session does not run
-            return dbusCall(LXQT_SERVICE, LXQT_PATH, LXQT_SERVICE,
-                            QDBusConnection::sessionBus(), "canLogout",
-                            PowerProvider::DontCheckDBUS);
+            command = "canLogout";
+            break;
+        case Power::PowerReboot:
+            command = "canReboot";
+            break;
+        case Power::PowerShutdown:
+            command = "canPowerOff";
+            break;
         default:
             return false;
     }
+
+    // there can be case when lxqtsession-session does not run
+    return dbusCall(LXQT_SERVICE, LXQT_PATH, LXQT_SERVICE,
+            QDBusConnection::sessionBus(), command,
+            PowerProvider::DontCheckDBUS);
 }
 
 
 bool LXQtProvider::doAction(Power::Action action)
 {
     QString command;
-
     switch (action)
     {
-    case Power::PowerLogout:
-        command = "logout";
-        break;
-
-    default:
-        return false;
+        case Power::PowerLogout:
+            command = "logout";
+            break;
+        case Power::PowerReboot:
+            command = "reboot";
+            break;
+        case Power::PowerShutdown:
+            command = "powerOff";
+            break;
+        default:
+            return false;
     }
 
     return dbusCall(LXQT_SERVICE,


### PR DESCRIPTION
To allow usage of LXQt::Power object inside of lxqt-session (handling
the called method of LXQtSessionProvider) we need to avoid recurently
calling lxqt-session itself.

supersedes the #121 

ref. lxde/lxqt#1311