### PR TITLE
lxqtpower: Add support for turning monitor(s) off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,8 @@ set(FORMS
     configdialog/lxqtconfigdialog.ui
 )
 
+file(GLOB LXQT_CONFIG_FILES resources/*.conf)
+
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -332,6 +334,11 @@ install(FILES
     ${INTREE_PORTABLE_HEADERS}
     DESTINATION "${LXQT_INSTALL_INCLUDE_DIR}/LXQt"
     COMPONENT Devel
+)
+
+install(FILES ${LXQT_CONFIG_FILES}
+    DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/lxqt"
+    COMPONENT Runtime
 )
 
 #************************************************

--- a/lxqtpower/lxqtpower.cpp
+++ b/lxqtpower/lxqtpower.cpp
@@ -88,9 +88,11 @@ bool Power::canHibernate() const { return canAction(PowerHibernate); }
 bool Power::canReboot()    const { return canAction(PowerReboot);    }
 bool Power::canShutdown()  const { return canAction(PowerShutdown);  }
 bool Power::canSuspend()   const { return canAction(PowerSuspend);   }
+bool Power::canMonitorOff() const { return canAction(PowerMonitorOff);   }
 
 bool Power::logout()       { return doAction(PowerLogout);    }
 bool Power::hibernate()    { return doAction(PowerHibernate); }
 bool Power::reboot()       { return doAction(PowerReboot);    }
 bool Power::shutdown()     { return doAction(PowerShutdown);  }
 bool Power::suspend()      { return doAction(PowerSuspend);   }
+bool Power::monitorOff()   { return doAction(PowerMonitorOff);   }

--- a/lxqtpower/lxqtpower.h
+++ b/lxqtpower/lxqtpower.h
@@ -53,7 +53,8 @@ public:
         PowerHibernate, /// Hibernate the comupter
         PowerReboot,    /// Reboot the computer
         PowerShutdown,  /// Shutdown the computer
-        PowerSuspend    /// Suspend the computer
+        PowerSuspend,   /// Suspend the computer
+        PowerMonitorOff /// Turn off the monitor(s)
     };
 
     /*!
@@ -88,6 +89,9 @@ public:
     //! This function is provided for convenience. It's equivalent to calling canAction(PowerSuspend).
     bool canSuspend() const;
 
+    //! This function is provided for convenience. It's equivalent to calling canAction(PowerMonitorOff).
+    bool canMonitorOff() const;
+
 public slots:
     /// Performs the requested action.
     bool doAction(Action action);
@@ -106,6 +110,9 @@ public slots:
 
     //! This function is provided for convenience. It's equivalent to calling doAction(PowerSuspend).
     bool suspend();
+
+    //! This function is provided for convenience. It's equivalent to calling doAction(PowerMonitorOff).
+    bool monitorOff();
 
 private:
     QList<PowerProvider*> mProviders;

--- a/lxqtpower/lxqtpowerproviders.cpp
+++ b/lxqtpower/lxqtpowerproviders.cpp
@@ -652,6 +652,9 @@ bool CustomProvider::canAction(Power::Action action) const
     case Power::PowerLogout:
         return mSettings.contains("logoutCommand");
 
+    case Power::PowerMonitorOff:
+        return mSettings.contains("monitorOffCommand");
+
     default:
         return false;
     }
@@ -681,6 +684,10 @@ bool CustomProvider::doAction(Power::Action action)
 
     case Power::PowerLogout:
         command = mSettings.value("logoutCommand").toString();
+        break;
+
+    case Power::PowerMonitorOff:
+        command = mSettings.value("monitorOffCommand").toString();
         break;
 
     default:

--- a/resources/power.conf
+++ b/resources/power.conf
@@ -1,0 +1,2 @@
+[General]
+monitorOffCommand=xset dpms force off


### PR DESCRIPTION
Added the new action PowerMonitorOff, which we currently support only
by the using the external command: xset dpms force off (that means only
CustomProvider does currently provide this action).

The used command is defaultly set in the global config file
/usr/share/lxqt/power.conf.

Note: this is X specific, but downstream can easily change the default
command by providing /etc/lxqt/power.conf...


needed by lxde/lxqt-powermanagement#62